### PR TITLE
fixed opts window

### DIFF
--- a/pm-cb-g
+++ b/pm-cb-g
@@ -354,7 +354,13 @@ sub show_options {
     my ($mw, $read, $write, $last_update, $opt_b) = @_;
     $opt_b->configure(-state => 'disabled');
     my $opt_w = $mw->Toplevel(-title => TITLE . ' Options');
-
+    $opt_w->protocol(WM_DELETE_WINDOW =>
+                        sub {
+                              $opt_b->configure(-state => 'active');
+                              $opt_w->destroy();
+                        }
+    );
+    
     my $opt_f = $opt_w->Frame(-relief => 'groove', -borderwidth => 2)
         ->pack(-padx => 5, -pady => 5);
 


### PR DESCRIPTION
disable th Options button is a good workaround to prevent multiple undesired instances of the window.
But if you close the windows with the upper right X the buttom remains disabled.
quick fix below