### PR TITLE
Add cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,7 @@ on build => sub {
     }
 };
 
+requires 'Syntax::Construct';
 requires 'Time::HiRes';
 requires 'Tk';
 requires 'WWW::Mechanize';

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,19 @@
+# BEGIN
+
+on configure => sub {
+    if ( `perl -V` =~ /useithreads=undef/ ) {
+        requires 'MCE::Hobo';
+        requires 'MCE::Shared';
+    } else {
+        requires 'Thread::Queue';
+        suggests 'MCE::Hobo';
+        suggests 'MCE::Shared';
+    };
+};
+
+requires 'Time::HiRes';
+requires 'Tk';
+requires 'WWW::Mechanize';
+requires 'XML::LibXML';
+
+# END

--- a/cpanfile
+++ b/cpanfile
@@ -1,11 +1,10 @@
 # BEGIN
 
-on configure => sub {
+on build => sub {
     if ( `perl -V` =~ /useithreads=undef/ ) {
         requires 'MCE::Hobo';
         requires 'MCE::Shared';
     } else {
-        requires 'Thread::Queue';
         suggests 'MCE::Hobo';
         suggests 'MCE::Shared';
     };

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,8 @@
 # BEGIN
+use Config;
 
 on build => sub {
-    if ( `perl -V` =~ /useithreads=undef/ ) {
+    if ( ! $Config{'usethreads'} ) {
         requires 'MCE::Hobo';
         requires 'MCE::Shared';
     } else {

--- a/cpanfile
+++ b/cpanfile
@@ -1,14 +1,15 @@
-# BEGIN
-use Config;
+# cpanfile
 
 on build => sub {
-    if ( ! $Config{'usethreads'} ) {
-        requires 'MCE::Hobo';
-        requires 'MCE::Shared';
-    } else {
+    my $does_threads = eval { require threads; 1 };
+
+    if ( $does_threads ) {
         suggests 'MCE::Hobo';
         suggests 'MCE::Shared';
-    };
+    } else {
+        requires 'MCE::Hobo';
+        requires 'MCE::Shared';
+    }
 };
 
 requires 'Time::HiRes';


### PR DESCRIPTION
Add a `cpanfile` to manage dependencies. 

```
[594] ► perlbrew use 5.26.1t

[595] ► perl -Mthreads -E 1

[596] ► cpanfile-dump cpanfile
Time::HiRes
Tk
WWW::Mechanize
XML::LibXML

[597] ► perlbrew use 5.26.1c

[598] ► perl -Mthreads -E 1
This Perl not built to support threads
Compilation failed in require.
BEGIN failed--compilation aborted.

[599] ► cpanfile-dump cpanfile
MCE::Hobo
MCE::Shared
Time::HiRes
Tk
WWW::Mechanize
XML::LibXML
```