### PR TITLE
Correctly parse aliased monks (e.g. [choroba|him])

### DIFF
--- a/lib/PM/CB/GUI.pm
+++ b/lib/PM/CB/GUI.pm
@@ -477,7 +477,7 @@ sub show {
             $url = '__PM_CB_URL__' . $id;
             $tag = "browse:$id|$name";
 
-        } elsif ($url eq $orig) {
+        } elsif ($orig =~ /^\Q$url\E\|?/) {
             substr $url, 0, 0, '__PM_CB_URL__';
             $tag = "browse:$url|$name";
         }


### PR DESCRIPTION
Previously, only words without an alias were translated into correct
links.