### PR TITLE
Require only thread unsafe libraries (Tk)

### DIFF
--- a/lib/PM/CB/Communication.pm
+++ b/lib/PM/CB/Communication.pm
@@ -4,6 +4,11 @@ use warnings;
 use strict;
 use Syntax::Construct qw{ // };
 
+use Encode;
+use Time::HiRes;
+use WWW::Mechanize;
+use XML::LibXML;
+
 use constant {
     FREQ             => 7,
     REPEAT_THRESHOLD => 3,
@@ -27,9 +32,6 @@ sub url { "https://$_[0]{pm_url}/bare/?node_id=" }
 
 sub communicate {
     my ($self) = @_;
-    require XML::LibXML;
-    require WWW::Mechanize;
-    require Time::HiRes;
 
     my $mech = $self->{mech}
         = 'WWW::Mechanize'->new(
@@ -123,7 +125,6 @@ sub get_monklist {
         }
         return
     }
-    require XML::LibXML;
     my $dom;
     eval {
         $dom = 'XML::LibXML'->load_xml(string => $self->mech_content);
@@ -162,7 +163,6 @@ sub handle_url {
                 return
             }
 
-            require XML::LibXML;
             my $dom;
             eval {
                 $dom = 'XML::LibXML'->load_xml(string => $self->mech_content)
@@ -267,7 +267,6 @@ sub mech_content {
     my ($self) = @_;
     # libxml respects encoding, but mech returns the page in unicode,
     # not windows-1252.
-    require Encode;
     my $content = Encode::encode('UTF-8', $self->{mech}->content);
     $content =~ s/windows-1252/utf-8/i;
     return $content

--- a/lib/PM/CB/GUI.pm
+++ b/lib/PM/CB/GUI.pm
@@ -4,6 +4,9 @@ use warnings;
 use strict;
 use Syntax::Construct qw{ // };
 
+use charnames ();
+use Time::Piece;
+
 
 use constant {
     TITLE        => 'PM::CB::G',
@@ -31,7 +34,6 @@ sub url {
 sub gui {
     my ($self) = @_;
 
-    require Time::Piece;
     my $tzoffset = Time::Piece::localtime()->tzoffset;
     $self->{last_date} = q();
 
@@ -435,7 +437,6 @@ sub seen {
 
 
 sub decode {
-    require charnames;
     my ($msg) = @_;
 
     $msg =~ s/&#(x?)([0-9a-f]+);/$1 ? chr hex $2 : chr $2/gei;


### PR DESCRIPTION
XML::LibXML, WWW::Mechanize, Time::HiRes, Encode, charnames, and
Time::Piece can be used normally.